### PR TITLE
Extend contextDump helper

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -20,6 +20,14 @@ function isSelect(context) {
   return typeof value === "object" && value.isSelect === true;
 }
 
+// Display functions as strings for contextDump
+function jsonFilter(key, value) {
+  if (typeof value === "function") {
+    return value.toString();
+  }
+  return value;   
+}
+
 function filter(chunk, context, bodies, params, filter) {
   var params = params || {},
       actual,
@@ -74,9 +82,33 @@ var helpers = {
     return bodies.block(chunk, context.push(context.stack.index));
   },
   
-  contextDump: function(chunk, context, bodies) {
-    _console.log(JSON.stringify(context.stack.head));
-    return chunk;
+  /**
+   * contextDump helper
+   * @param key specifies how much to dump. 
+   * "current" dumps current context. "full" dumps the full context stack.
+   * @param to specifies where to write dump output. 
+   * Values can be "console" or "output". Default is output.
+   */
+  contextDump: function(chunk, context, bodies, params) {
+    var p = params || {},
+      to = p.to || 'output',
+      key = p.key || 'current',
+      dump;
+    to = dust.helpers.tap(to, chunk, context),
+    key = dust.helpers.tap(key, chunk, context);
+    if (key === 'full') {
+      dump = JSON.stringify(context.stack, jsonFilter, 2);
+    }
+    else {
+      dump = JSON.stringify(context.stack.head, jsonFilter, 2);
+    }
+    if (to === 'console') {
+      _console.log(dump);
+      return chunk;
+    }
+    else {
+      return chunk.write(dump);
+    }
   },
   
   // Utility helping to resolve dust references in the given chunk

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -531,6 +531,34 @@ var helpersTests = [
       context:  {"A": [ {"B": [ {"C": ["Ca1", "C2"]}, {"C": ["Ca2", "Ca22"]} ] }, {"B": [ {"C": ["Cb1", "C2"]}, {"C": ["Cb2", "Ca2"]} ] } ] },
       expected: "A loop:0-2,B loop:0-2C[0]=Ca1 B loop:1-2C[0]=Ca2 A loop trailing: 0-2A loop:1-2,B loop:0-2C[0]=Cb1 B loop:1-2C[0]=Cb2 A loop trailing: 1-2",
       message: "test array reference $idx/$len nested loops"
+  },
+  {
+      name:     "contextDump simple test",
+      source:   "{@contextDump/}",
+      context:  {A:2, B:3},
+      expected: "{\n  \"A\": 2,\n  \"B\": 3\n}",
+      message: "contextDump simple test"
+  },
+  {
+      name:     "contextDump simple test dump to console",
+      source:   "{@contextDump to=\"console\"/}",
+      context:  {A:2, B:3},
+      expected: "",
+      message: "contextDump simple test"
+  },
+  {
+      name:     "contextDump full test",
+      source:   "{@contextDump key=\"full\"/}",
+      context:  {aa:{A:2, B:3}},
+      expected: "{\n  \"isObject\": true,\n  \"head\": {\n    \"aa\": {\n      \"A\": 2,\n      \"B\": 3\n    }\n  }\n}",
+      message: "contextDump full test"
+  },
+  {
+      name:     "contextDump function dump test",
+      source:   "{#aa param=\"{p}\"}{@contextDump key=\"full\"/}{/aa}",
+      context:  {aa:["a"],p:42},
+      expected: "{\n  \"tail\": {\n    \"tail\": {\n      \"isObject\": true,\n      \"head\": {\n        \"aa\": [\n          \"a\"\n        ],\n        \"p\": 42\n      }\n    },\n    \"isObject\": true,\n    \"head\": {\n      \"param\": \"function body_2(chk,ctx){return chk.reference(ctx.get(\\\"p\\\"),ctx,\\\"h\\\");}\",\n      \"$len\": 1,\n      \"$idx\": 0\n    }\n  },\n  \"isObject\": false,\n  \"head\": \"a\",\n  \"index\": 0,\n  \"of\": 1\n}",
+      message: "contextDump function dump test"
   }
 ];
 


### PR DESCRIPTION
Extend contextDump helper to dump to console or output. Support current or full stack dump. Beautify stack dump and make it show function objects as string.  Add tests.
