### PR TITLE
Updated README to install node dependencies properly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules
+*.DS_Store

--- a/test/README.md
+++ b/test/README.md
@@ -14,9 +14,11 @@ If you want to run the client version just open the html page called specRunner.
 
 Pre-requisites for tests on node server version: 
 ----------------------------------
-* install nodejs 0.6 or greater 
+* install nodejs 0.6 or greater
 * install npm
-* install jasmine test framework : npm install -g jasmine-node
+* install testing dependencies by running in the package directory:
+
+     npm install
 
 In order to run the node.js version of dust, run this command in the terminal
 


### PR DESCRIPTION
Previously the README suggested installing jasmine globally (frowned upon) and didn't cover installing dustjs-linkedin at all (which of course would in turn break tests). This is what package.json is for - no need to list the dependencies again in the README. Runing npm install in the project directory takes care of all things
