### PR TITLE
Create access helper to support path references up stack

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -69,6 +69,40 @@ function coerce (value, type, context) {
   return value;
 }
 
+// Walk up stack, find the requested path and return the value
+function getPathUp (stack, down) {
+  var stk = stack,
+    key = down[0],
+    value, i, len;
+    // Walk the stack up looking for the path
+  while (stk) {
+    if (stk.isObject) {
+      if (!(stk.head[key] === undefined)) {
+        // found a possible start to down path, follow it and see if rest matches
+        len = down.length;
+        hstk = stk.head[key];
+        // Check that each level down has a match starting with 2nd elt. First already matched.
+        i = 1;
+        while(hstk && i < len) {
+          hstk = hstk[down[i]];
+          i++;
+        }
+        // If it matched all the way down, return hit
+       if (hstk) {
+          return hstk;
+        }
+      }
+    } else {
+      if (stk.tail === 'undefined') {
+        return '';
+      }
+    }
+    // Climb up another stack level
+    stk = stk.tail;
+  }
+  return '';
+}
+
 var helpers = {
   
   sep: function(chunk, context, bodies) {
@@ -82,6 +116,55 @@ var helpers = {
     return bodies.block(chunk, context.push(context.stack.index));
   },
   
+/**
+ * access helper to access path value up the context stack.
+ * @param key specifies path to dump.
+ * key values will normally be paths that are up the stack. However,
+ * paths at the current context will work, simple key names will work,
+ * and things like ., .name, will work. There is no point using this
+ * helper for simple keys and current context references but they do
+ * work to avoid surprise for the user.
+ * In addition to pathed names, it handles references containing subscripts.
+ * Note that it does not support $idx, $len. This could be done but is a
+ * non-trivial amount of work and does not really relate to normal usage
+ * of this helper. It will be documented as a restriction.
+ */
+  access: function (chk, ctx, bodies, params) {
+    var key = dust.helpers.tap(params.key, chk, ctx),
+      nosubs = key.replace(']', ''),
+      parts, val;
+    nosubs =  nosubs.replace('[','.');
+    // Special case .xxxx which will not be a path up
+    if (nosubs.charAt(0) === '.') {
+      nosubs = nosubs.substr(1);
+    }
+    parts = nosubs.split('.');
+    // Finish special case of .xxx forms to give same result as {.xxx}
+    if (key.charAt(0) === '.') {
+      if (key === '.') {
+        parts =[];
+      }
+      val = ctx.getPath(true,  parts);
+      return chk.write(val);
+    }
+    // If only one name in key, treat same as {xxx} reference
+    if (parts.length === 1) {
+      val = ctx.get(key);
+      if ( typeof val === 'undefined') {
+        return chk;
+      }
+      return chk.write(ctx.get(key));
+    }
+    // See if findable in current context
+    val = ctx.getPath(false, parts);
+    if (val) {
+      return chk.write(val);
+     }
+    //Look for it up the stack
+    val = getPathUp(ctx.stack, parts);
+    return chk.write(val);
+},
+ 
   /**
    * contextDump helper
    * @param key specifies how much to dump. 

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -568,7 +568,71 @@ var helpersTests = [
       context:  {aa:["a"],p:42},
       expected: "{\n  \"tail\": {\n    \"tail\": {\n      \"isObject\": true,\n      \"head\": {\n        \"aa\": [\n          \"a\"\n        ],\n        \"p\": 42\n      }\n    },\n    \"isObject\": true,\n    \"head\": {\n      \"param\": \"function body_2(chk,ctx){return chk.reference(ctx.get(\\\"p\\\"),ctx,\\\"h\\\");}\",\n      \"$len\": 1,\n      \"$idx\": 0\n    }\n  },\n  \"isObject\": false,\n  \"head\": \"a\",\n  \"index\": 0,\n  \"of\": 1\n}",
       message: "contextDump function dump test"
+  },
+  {
+      name:     "access helper find in current context test",
+      source:   "{#A}{#B}{@access key=\"C.name\" /}{/B}{/A}",
+      context:  {A: {B: {C:{name: "a-b-c"}}}},
+      expected: "a-b-c",
+      message: "access helper find in current context test"
+  },
+  {
+      name:     "access helper find in parent level test",
+      source:   "{#A}{#B}{#C}{@access key=\"A.B.name\" /}{/C}{/B}{/A}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"}}},
+      expected: "a-b",
+      message: "access helper find in parent level test"
+  },
+  {
+      name:     "access helper find in parent level test",
+      source:   "{#A.B.C}{@access key=\"A.name\" /}{/A.B.C}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"},A:{name:"a-a"},name:"a"}},
+      expected: "a",
+      message: "access helper find in parent level test"
+  },
+  {
+      name:     "access helper with subscript find up test",
+      source:   "{#A}{#B}{@access key=\"D[0].A.name\" /}{/B}{/A}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"},A:{name:"a-a"},name:"a"},D:[{A:{name: "D[0].A"}},{B:{name:"D[1].B"}}]},
+      expected: "D[0].A",
+      message: "access helper with subscript find up test"
+  },
+  {
+      name:     "access helper with non-path key test",
+      source:   "{#A.B.C}{@access key=\"name\" /}{/A.B.C}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"},A:{name:"a-a"},name:"a"},D:[{A:{name: "D[0].A"}},{B:{name:"D[1].B"}}]},
+      expected: "a-b-c",
+      message: "access helper with non-path key test"
+  },
+  {
+      name:     "access helper with simple . key test",
+      source:   "{#loop2}{@access key=\".\"/}{/loop2}",
+      context:  {loop2: ["ab", "de"]},
+      expected: "abde",
+      message: "access helper with simple . key test"
+  },
+  {
+      name:     "access helper with  .name key test",
+      source:   "{#loop}{@access key=\".name\"/}{/loop}",
+      context:  {loop: [{name:"ab"}, {name:"de"}]},
+      expected: "abde",
+      message: "access helper with .name key test"
+  },
+  {
+      name:     "access helper with context used test",
+      source:   "{#D:A.B}{@access key=\"C.name\" /}{/D}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"},A:{name:"a-a"},name:"a"},D:[{A:{name: "D[0].A"}},{B:{name:"D[1].B"}}]},
+      expected: "a-b-ca-b-c",
+      message: "access helper with context used test"
+  },
+  {
+      name:     "access helper with context, test can't reach out of context ",
+      source:   "{#D:A.B}{@access key=\"A.A.name\" /}{/D}",
+      context:  {A: {B: {C:{name: "a-b-c"},name: "a-b"},A:{name:"a-a"},name:"a"},D:[{A:{name: "D[0].A"}},{B:{name:"D[1].B"}}]},
+      expected: "",
+      message: "access helper with context, test can't reach out of context"
   }
+
 ];
 
 if (typeof module !== "undefined" && typeof require !== "undefined") {


### PR DESCRIPTION
Add a new {@access key="path" /} helper that allows referencing paths that are up stack from the current context. Add a bunch of tests to cover use cases.  Sample usages are:

{@access key="a.b.c" /}
{@access key="a.b[2]" /}

Though not the intended use case paths like ".", ".name", "name" are allowed and return the same as {.}, {.name}, {name} although the latter are the preferred ways to do these things.

JSdoc is in the code. Wiki doc will be added after PR is accepted.
