### PR TITLE
Fix for global leaks (causing all mocha tests to fail)

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -1,18 +1,3 @@
-var whereToAppend;
-
-if (typeof exports !== 'undefined') {
-    whereToAppend = require('dustjs-linkedin');
-
-    module.exports = whereToAppend;
-} else {
-    if (typeof dust !== 'undefined') {
-        whereToAppend = dust;
-    } else {
-        throw new Error('the dustjs core library has to be loaded');
-    }
-}
-
-
 (function(dust){
 
 // Note: all error conditions are logged to console and failed silently
@@ -500,4 +485,4 @@ var helpers = {
 
 dust.helpers = helpers;
 
-})(whereToAppend);
+})(typeof exports !== 'undefined' ? module.exports = require('dustjs-linkedin') : dust);


### PR DESCRIPTION
Referencing issue #36 (https://github.com/linkedin/dustjs-helpers/issues/36) I did a few adjustments an the loading of the dust-core library for browser and the server side so that no global leaks will result.
