### PR TITLE
checking for the typeof value for being an object is not sufficient

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -14,7 +14,7 @@ var _console = (typeof console !== 'undefined')? console: {
 
 function isSelect(context) {
   var value = context.current();
-  return typeof value === "object" && value.isSelect === true;
+  return value && typeof value === "object" && value.isSelect === true;
 }
 
 // Utility method : toString() equivalent for functions

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1033,7 +1033,7 @@ var helpersTests = [
           context:  { myboolean: true },
           expected: "you have 0 new messages",
           message: "should test if size helper is working properly with boolean true"
-      }, 
+      },
       {
         name:     "size helper with object",
         source:   'you have {@size key=myValue/} new messages',
@@ -1202,6 +1202,18 @@ var helpersTests = [
                   },
         expected: "3, 2, 1",
         message: "should sep helper in a async_iterator"
+      }
+    ]
+  },
+  {
+    name: "error",
+    tests: [
+      {
+        name:     "falsy data",
+        source:   '{#d}{@eq key=a value="bar"}equal{:else}bar{/eq}{/d}',
+        context:  {"d":[null]},
+        expected: "",
+        message: "should not crash if data is invalid"
       }
     ]
   }


### PR DESCRIPTION
null also is of type object. this will result in an application crash e.g. when the eq-helper is called without an key.