### PR TITLE
Fix for unstable comparison between string and float and upgrading jasmine-node

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -237,42 +237,45 @@ var helpers = {
           round = params.round,
           mathOut = null,
           operError = function(){_console.log("operand is required for this math method"); return null;};
-      key  = dust.helpers.tap(key, chunk, context);
-      operand = dust.helpers.tap(operand, chunk, context);
+      key  = parseFloat(dust.helpers.tap(key, chunk, context));
+      operand = parseFloat(dust.helpers.tap(operand, chunk, context));
       //  TODO: handle  and tests for negatives and floats in all math operations
       switch(method) {
         case "mod":
           if(operand === 0 || operand === -0) {
             _console.log("operand for divide operation is 0/-0: expect Nan!");
           }
-          mathOut = parseFloat(key) %  parseFloat(operand);
+          mathOut = key % operand;
           break;
         case "add":
-          mathOut = parseFloat(key) + parseFloat(operand);
+          mathOut = key + operand;
           break;
         case "subtract":
-          mathOut = parseFloat(key) - parseFloat(operand);
+          mathOut = key - operand;
           break;
         case "multiply":
-          mathOut = parseFloat(key) * parseFloat(operand);
+          mathOut = key * operand;
           break;
         case "divide":
-         if(operand === 0 || operand === -0) {
-           _console.log("operand for divide operation is 0/-0: expect Nan/Infinity!");
-         }
-          mathOut = parseFloat(key) / parseFloat(operand);
+          if(operand === 0 || operand === -0) {
+            _console.log("operand for divide operation is 0/-0: expect Nan/Infinity!");
+          }
+          mathOut = key / operand;
           break;
         case "ceil":
-          mathOut = Math.ceil(parseFloat(key));
+          mathOut = Math.ceil(key);
           break;
         case "floor":
-          mathOut = Math.floor(parseFloat(key));
+          mathOut = Math.floor(key);
           break;
         case "round":
-          mathOut = Math.round(parseFloat(key));
+          mathOut = Math.round(key);
           break;
         case "abs":
-          mathOut = Math.abs(parseFloat(key));
+          mathOut = Math.abs(key);
+          break;
+        case "toint":
+          mathOut = parseInt(key);
           break;
         default:
           _console.log( "method passed is not supported" );

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "keywords": ["templates", "views", "helpers"],
   "devDependencies": {
-    "jasmine-node"   :  "1.0.x",
+    "jasmine-node"   :  "1.11.x",
     "cover"          :  "0.2.x",
     "dustjs-linkedin":  "1.1.x"
   },

--- a/test/jasmine-test/server/specRunner.js
+++ b/test/jasmine-test/server/specRunner.js
@@ -35,7 +35,7 @@ process.argv.forEach(function(arg) {
   }
 });
 
-jasmine.executeSpecsInFolder(path.dirname(__dirname) + '/spec', (function(runner, log) {
+jasmine.executeSpecsInFolder({'specFolders':[path.dirname(__dirname) + '/spec']}, (function(runner, log) {
   if (runner.results().failedCount === 0) {
     return process.exit(0);
   } else {


### PR DESCRIPTION
 * The condition `operand === 0 || operand === -0` will never be met, if the operand is a string. Demo http://jsfiddle.net/prHDQ/

 * Introducing a new function `toint` which converts a floating point number to an integer.

 * Upgrading `jasmine-node`. The older version of jasmine-node fails when the node's version has a two digit version number. I had to upgrade this to run the tests.