### PR TITLE
Fix issue with unit tests and add `addToContext` helper

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -12,6 +12,53 @@ var _console = (typeof console !== 'undefined')? console: {
    }
 };
 
+
+/**
+  * Tries to take a value that's a certain type (typically a string) and coerce it in to another type.
+  * Tests: http://pastebin.com/jzne84Kd
+  * Perf Tests: http://jsperf.com/type-coercion-test
+  * Results: http://bit.ly/WgbcJX
+  * @param {string} value
+  * @param {string} type
+  * @param {*} context
+  * @return {*}
+  * @private
+  */
+var coerce = function(value, type, context) {
+  if (type === 'number') {
+    value = Number(value);
+  }else if (type === 'string') {
+    value += '';
+  }else if (type === 'boolean') {
+    if (value === 'true') value = true;
+    else if (value === 'false') value = false;
+    else value = !!value;
+  }else if (type === 'date') {
+    value = new Date(value);
+  }else if (type === 'context' && context) {
+    value = context.get(value);
+  }
+  return value;
+};
+
+/**
+  * Helper method for trimming a string. Will default to native implementation if available, otherwise
+  * will use code defined here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/Trim#Compatibility
+  * @param {string} value
+  * @return {string}
+  * @private
+  */
+var trim = (function() {
+  var t = String.prototype.trim;
+  return typeof t === 'function' ? function(value) {
+    return t.call(value);
+  } : function(value) {
+    return ('' + value).replace(/^\s+|\s+$/g, '');
+  };
+}());
+
+
+
 function isSelect(context) {
   var value = context.current();
   return typeof value === "object" && value.isSelect === true;
@@ -66,23 +113,6 @@ function filter(chunk, context, bodies, params, filterOp) {
     return chunk.render(bodies['else'], context);
   }
   return chunk;
-}
-
-function coerce (value, type, context) {
-  if (value) {
-    switch (type || typeof(value)) {
-      case 'number': return +value;
-      case 'string': return String(value);
-      case 'boolean': {
-        value = (value === 'false' ? false : value);
-        return Boolean(value);
-      }
-      case 'date': return new Date(value);
-      case 'context': return context.get(value);
-    }
-  }
-
-  return value;
 }
 
 var helpers = {
@@ -486,8 +516,34 @@ var helpers = {
       value = (key + '').length; //any other value (strings etc.)
     }
     return chunk.write(value);
+  },
+
+  /**
+    * Will capture the helper's body and will add a new property to the current context scope with the value.
+    * If the type param is passed in, will optionally coerce value in to that type.
+    * {*} chunk
+    * {*} context
+    * {*} bodies
+    * {Object} params
+    *  @param {String} params.name
+    *  @param {String} [params.type]
+    * @return {*}
+    */
+  addToContext: function( chunk, context, bodies, params ) {
+    var name = params && params.name,
+        type = params && params.type;
+    if (name) {
+      return chunk.capture(bodies.block, context, function(data, chunk) {
+
+        //save results (note: data always comes back as a string)
+        context.current()[name] = type ? coerce(trim(data), type) : data;
+
+        //tell dust we're done
+        chunk.end();
+      });
+    }
+    return chunk;
   }
-  
   
 };
 

--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -519,12 +519,12 @@ var helpers = {
   },
 
   /**
-    * Will capture the helper's body and will add a new property to the current context scope with the value.
+    * Will capture the helper's body and add a new property to the current context scope with the value.
     * If the type param is passed in, will optionally coerce value in to that type.
-    * {*} chunk
-    * {*} context
-    * {*} bodies
-    * {Object} params
+    * @param {*} chunk
+    * @param {*} context
+    * @param {*} bodies
+    * @param {Object} params
     *  @param {String} params.name
     *  @param {String} [params.type]
     * @return {*}

--- a/test/jasmine-test/server/specRunner.js
+++ b/test/jasmine-test/server/specRunner.js
@@ -35,10 +35,16 @@ process.argv.forEach(function(arg) {
   }
 });
 
-jasmine.executeSpecsInFolder(path.dirname(__dirname) + '/spec', (function(runner, log) {
+var options = {};
+options['specFolder'] = path.dirname(__dirname) + '/spec';
+options['isVerbose'] = isVerbose;
+options['showColors'] = showColors;
+options['onComplete'] = function(runner, log) {
   if (runner.results().failedCount === 0) {
     return process.exit(0);
   } else {
     return process.exit(1);
   }
-}), isVerbose, showColors);
+};
+
+jasmine.executeSpecsInFolder(options);

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1204,6 +1204,89 @@ var helpersTests = [
         message: "should sep helper in a async_iterator"
       }
     ]
+  },
+  {
+    name: "addToContext",
+    tests: [{
+        name:     "test basic addToContext",
+        source:   '{@addToContext name="value"}{name}{/addToContext} {value}',
+        context:  { name: 'Rick Ross' },
+        expected: " Rick Ross",
+        message: "should test addToContext helper for basic support"
+    }, {
+        name:     "test basic addToContext2",
+        source:   'Before: {foo};{@addToContext name="foo"}bar{/addToContext}; After: {foo}',
+        context:  { },
+        expected: "Before: ;; After: bar",
+        message: "should test addToContext helper for basic support"
+    }, {
+        name:     "test basic addToContext with static string",
+        source:   '{@addToContext name="cardClass" }{?isHidden}is-hidden{:else}is-not-hidden{/isHidden}{/addToContext} {cardClass}',
+        context:  { isHidden: true },
+        expected: " is-hidden",
+        message: "should test addToContext helper for basic support with static string"
+    }, {
+        name:     "test boolean coercion in addToContext",
+        source:   '{@addToContext name="isHidden" type="boolean"}{boolean_as_string}{/addToContext} {^isHidden}Something isn\'t hidden{/isHidden}',
+        context:  { boolean_as_string: 'false' },
+        expected: " Something isn\'t hidden",
+        message: "should test addToContext helper for boolean coercion support"
+    }, {
+        name:     "test date coercion in addToContext",
+        source:   '{@addToContext name="value" type="date"}{date}{/addToContext} {value}',
+        context:  { date: 'not a real date.' },
+        expected: " Invalid Date",
+        message: "should test addToContext helper for date coercion support"
+    }, {
+        name:     "test string coercion in addToContext",
+        source:   '{@addToContext name="value" type="string"}{^bool}false{/bool}{/addToContext} {#value}the string \'false\' should pass as truthy, but, the boolean false will not{/value}',
+        //source: 'BASICS {bool}',
+        context:  { bool: false},
+        expected: " the string \'false\' should pass as truthy, but, the boolean false will not",
+        message: "should test addToContext helper for string coercion support"
+    }, {
+        name:     "test sibling addToContext support",
+        source:   '{@addToContext name="literal" type="number"}1{/addToContext} {@addToContext name="to_bool" type="boolean"}{literal}{/addToContext} {to_bool}',
+        context:  { },
+        expected: "  true",
+        message: "should test that sibling addToContexts have access to each others values"
+    }, {
+        name:     "test nested addToContext support",
+        source:   '{@addToContext name="bool" type="boolean"}{@addToContext name="num" type="number"}1{/addToContext}-{num}{/addToContext} {bool}',
+        context:  { },
+        expected: " true",
+        message: "should test that nested addToContext calls resolve correctly"
+    }, {
+        name:     "test basic addToContext for overriding existing properties",
+        source:   '{@addToContext name="value" type="boolean"}true{/addToContext} {value}',
+        context:  { value: 'this value already exists.'},
+        expected: " true",
+        message: "should test that addToContext will override a value on the context if it already exists."
+    }, {
+        name:     "test basic addToContext for overriding existing properties with empty content",
+        source:   '{@addToContext name="value"}{/addToContext} {value}',
+        context:  { value: 'this value already exists.'},
+        expected: " ",
+        message: "should test that addToContext will override a value on the context if it already exists even if it's empty."
+    }, {
+        name:     "test inline partials with addToContext",
+        source:   '{<inlinePartial}I am an inline partial!{/inlinePartial}{@addToContext name="value"}{+inlinePartial/}{/addToContext} The value is: {value}',
+        context:  { },
+        expected: " The value is: I am an inline partial!",
+        message: "should test that addToContext will add the output of an inline partial to the context."
+    }, {
+        name:     "test partials with addToContext",
+        source:   '{@addToContext name="value"}{>hello_there/}{/addToContext} The value is: {value}',
+        context:  { name: "Betsy Ross", count: 32 },
+        expected: " The value is: Hello Betsy Ross! You have 32 new messages.",
+        message: "should test that addToContext will add the output of a partial to the context."
+    }, {
+        name:     "test sections inside of addToContext",
+        source:   '{@addToContext name="value"}{#section}{name}{/section}{/addToContext} The value is: {value}',
+        context:  { section: { name: 'Bob Ross'} },
+        expected: " The value is: Bob Ross",
+        message: "should test that sections/setting new scope will still work with addToContext."
+    }]
   }
 ];
 

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1160,7 +1160,7 @@ var helpersTests = [
           name:     "contextDump function dump test",
           source:   "{#aa param=\"{p}\"}{@contextDump key=\"full\"/}{/aa}",
           context:  { "aa": ["a"], "p" : 42},
-          expected: "{\n  \"tail\": {\n    \"tail\": {\n      \"isObject\": true,\n      \"head\": {\n        \"aa\": [\n          \"a\"\n        ],\n        \"p\": 42\n      }\n    },\n    \"isObject\": true,\n    \"head\": {\n      \"param\": \"function body_2(chk,ctx){return chk.reference(ctx.get(\\\"p\\\"),ctx,\\\"h\\\");}\",\n      \"$len\": 1,\n      \"$idx\": 0\n    }\n  },\n  \"isObject\": false,\n  \"head\": \"a\",\n  \"index\": 0,\n  \"of\": 1\n}",
+          expected: "{\n  \"tail\": {\n    \"tail\": {\n      \"isObject\": true,\n      \"head\": {\n        \"aa\": [\n          \"a\"\n        ],\n        \"p\": 42\n      }\n    },\n    \"isObject\": true,\n    \"head\": {\n      \"param\": \"function body_2(chk,ctx){return chk.reference(ctx._get(false, [\\\"p\\\"]),ctx,\\\"h\\\");}\",\n      \"$len\": 1,\n      \"$idx\": 0\n    }\n  },\n  \"isObject\": false,\n  \"head\": \"a\",\n  \"index\": 0,\n  \"of\": 1\n}",
           message: "contextDump function dump test"
       }
     ]

--- a/test/jasmine-test/spec/renderTestSpec.js
+++ b/test/jasmine-test/spec/renderTestSpec.js
@@ -2,12 +2,29 @@ describe ("Test the basic functionality of dust", function() {
   for (var index = 0; index < helpersTests.length; index++) {
     for (var i = 0; i < helpersTests[index].tests.length; i++) {
       var test = helpersTests[index].tests[i];
-      it ("RENDER: " + test.message, render(test));
-      it ("STREAM: " + test.message, stream(test));
-      it ("PIPE: " + test.message, pipe(test));
+
+      it ("RENDER: " + test.message, render(clone(test)));
+      it ("STREAM: " + test.message, stream(clone(test)));
+      it ("PIPE: " + test.message, pipe(clone(test)));
     }
   };
 });
+
+function clone(o) {
+  var c = {};
+  for (var prop in o) {
+    var val = o[prop],
+        type = Object.prototype.toString.call(val);
+    if (type === '[object Object]') {
+      c[prop] = clone(val);
+    }else if (type === '[object Array]') {
+      c[prop] = [].concat(val);
+    }else {
+      c[prop] = val;
+    }
+  }
+  return c;
+}
 
 function render(test) {
   return function() {


### PR DESCRIPTION
This PR does a few things:

* Fixes issue with jasmine
* Fixes broken unit test for `@contextDump`
* Updates the `coerce` private function (in dust-helpers.js) to be more consistent w/ coercion for various values. There's not a major loss in perf for what we're gaining in coercion support.
* Adds an addToContext helper which will capture the body of the helper and add the results to the current context using a name that's passed in as a parameter. It will optionally try to coerce the value to a type passed via a type parameter.