### PR TITLE
configure keepRunner from command line

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -82,7 +82,7 @@ module.exports = function (grunt) {
       allTests : {
         src : '<%=paths.helpersMin%>',
         options: {
-          keepRunner: false,
+          keepRunner: grunt.option('keepRunner'),
           specs:   ['<%=paths.test%>/testUtils.js', '<%=paths.testSpecs%>/renderTestSpec.js'],
           helpers: ['<%=paths.testSpecs%>/helpersTests.js'],
           vendor:  ['<%=paths.dust%>'],


### PR DESCRIPTION
As discussed in https://github.com/linkedin/dustjs-helpers/pull/64#issuecomment-33403542 - keepRunner is currently hardcoded and needs to be edited manually to keep the client-side specRunner after executing the jasmine:allTests task.

Using grunt.option allows this value to be configured through the command line.  This also maintains backwards compatibility because the absence of this parameter on the command line means the return value is false.