### PR TITLE
Allow debugging unminified source code. Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,5 +36,19 @@ A quick tutorial for how to use Dust <https://github.com/linkedin/dustjs/wiki/Du
 
 * Go to github and post a pull request, see <https://help.github.com/articles/creating-a-pull-request>
 
+## Debugging
+To debug code in a browser run `grunt dev` task. It will generate jasmine spec runner and serve it on `http://localhost:3000/_SpecRunner.html` URL.
+Generated spec runner references unminified dust-helpers.js and dust-full.js files. This will allow you to easily step through the code and set up breakpoints.
+This task also watches changes to lib directory, so you can simply refresh the page to see the changes without a need to re-run `grunt dev` task. Press `Ctrl + C` to disconnect from server.
+
+## Using watch
+`grunt watch` will monitor dust-helpers.js and test spec files. Whenever change is made to those files, it will jshint them and run unit tests in Phantom (will not run them in node or rhino).
+ It is handy way to keep testing your changes without a need to manually run `grunt testPhantom` task.
+ Be sure to run `grunt test` before sending pull request. It will test your change in all environments and make sure that a travis build for your pull request succeeds.
+
+## Testing minified code in browser
+Use `grunt testClient` to test prod version code in any browser. Similarly to `grunt dev` task it will host spec runner on `http://localhost:3000/_SpecRunner.html` URL.
+
 ## Coverage report
-Running `grunt test` or `grunt testPhantom` generates coverage report under `tmp/coverage` folder. Open `index.html` file in a browser to view the coverage.
+Task `grunt coverage` runs jasmine unit tests against unminified source code and generates coverage report under `tmp/coverage` folder.
+Open `index.html` file in a browser to view the coverage.

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -17,7 +17,8 @@ module.exports = function (grunt) {
       helpersMin:       '<%=paths.build%>/dust-helpers.min.js',
       test:             '<%=paths.project%>/test',
       testSpecs:        '<%=paths.test%>/jasmine-test/spec',
-      dust:             '<%=paths.project%>/node_modules/dustjs-linkedin/dist/dust-full.min.js',
+      dust:             '<%=paths.project%>/node_modules/dustjs-linkedin/dist/dust-full.js',
+      dustMin:          '<%=paths.project%>/node_modules/dustjs-linkedin/dist/dust-full.min.js',
       dist:             '<%=paths.project%>/dist',
       archive:          '<%=paths.project%>/archive'
     },
@@ -79,24 +80,54 @@ module.exports = function (grunt) {
       }
     },
     jasmine : {
-      allTests : {
+      /*tests production (minified) code*/
+      testProd : {
         src : '<%=paths.helpersMin%>',
         options: {
           keepRunner: false,
           specs:   ['<%=paths.test%>/testUtils.js', '<%=paths.testSpecs%>/renderTestSpec.js'],
           helpers: ['<%=paths.testSpecs%>/helpersTests.js'],
-          vendor:  ['<%=paths.dust%>'],
+          vendor:  ['<%=paths.dustMin%>']
+        }
+      },
+      /*tests unminified code, mostly used for debugging by `grunt dev` task*/
+      testDev : {
+        src: '<%=paths.helpers%>',
+        options : {
+          keepRunner: false,
+          specs :   '<%=jasmine.testProd.options.specs%>',
+          helpers : '<%=jasmine.testProd.options.helpers%>',
+          vendor :  ['<%=paths.dust%>']
+        }
+      },
+      /* Used for coverage report only based on unminified code.
+         Not suited for debugging because istanbul decorates and jumbles code*/
+      coverage : {
+        src: '<%=paths.helpers%>',
+        options : {
+          keepRunner: false,
+          specs :   '<%=jasmine.testProd.options.specs%>',
+          helpers : '<%=jasmine.testProd.options.helpers%>',
+          vendor :  '<%=jasmine.testProd.options.vendor%>',
           template: require('grunt-template-jasmine-istanbul'),
           templateOptions: {
             coverage: '<%=paths.build%>/coverage/coverage.json',
             report: '<%=paths.build%>/coverage',
             thresholds: {
-              lines: 75,
-              statements: 75,
-              branches: 75,
-              functions: 90
+              lines: 90,
+              statements: 90,
+              branches: 85,
+              functions: 80
             }
           }
+        }
+      }
+    },
+    connect: {
+      testServer: {
+        options: {
+          port: 3000,
+          keepalive: false
         }
       }
     },
@@ -175,7 +206,36 @@ module.exports = function (grunt) {
         commitFiles: ['-a'],
         createTag: true
       }
+    },
+    log : {
+      testClient: {
+        message: 'Navigate to http://localhost:<%= connect.testServer.options.port %>/_SpecRunner.html\nCtrl-C to kill the server.'
+      },
+      coverage: {
+        message: 'Open <%=jasmine.coverage.options.templateOptions.report%>/index.html in the browser to view the coverage.'
+      }
+    },
+    watch: {
+      lib: {
+        files: ['<%=paths.lib%>/**/*.js'],
+        tasks: ['clean:build', 'buildLib']
+      },
+      gruntfile: {
+        files: '<%= jshint.gruntfile.src %>',
+        tasks: ['jshint:gruntfile']
+      },
+      lib_test: {
+        files: ['<%=paths.lib%>/**/*.js', '<%=paths.testSpecs%>/**/*.js'],
+        tasks: ['testPhantom']
+      }
     }
+  });
+
+  //--------------------------------------------------
+  //------------Custom tasks -------------------------
+  //--------------------------------------------------
+  grunt.registerMultiTask('log', 'Print messages defined via config', function() {
+    grunt.log.ok(this.data.message);
   });
 
   //--------------------------------------------------
@@ -186,6 +246,8 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-compress');
   grunt.loadNpmTasks('grunt-bump');
   grunt.loadNpmTasks('grunt-shell');
@@ -193,19 +255,29 @@ module.exports = function (grunt) {
   //--------------------------------------------------
   //------------Grunt task aliases -------------------
   //--------------------------------------------------
-  grunt.registerTask('build',   ['jshint', 'clean:build', 'copy:build', 'uglify:build']);
+  grunt.registerTask('buildLib',     ['jshint:libs', 'copy:build']);
+  grunt.registerTask('build',        ['clean:build', 'jshint:testSpecs', 'buildLib', 'uglify:build']);
 
   //test tasks
-  grunt.registerTask('testNode',    ['build', 'shell:testNode']);
-  grunt.registerTask('testRhino',   ['build', 'shell:testRhino']);
-  grunt.registerTask('testPhantom', ['build', 'jasmine']);
-  grunt.registerTask('test',        ['build', 'jasmine', 'shell:testNode', 'shell:testRhino']);
+  grunt.registerTask('testNode',     ['build', 'shell:testNode']);
+  grunt.registerTask('testRhino',    ['build', 'shell:testRhino']);
+  grunt.registerTask('testPhantom',  ['build', 'jasmine:testProd']);
+  grunt.registerTask('test',         ['build', 'jasmine:testProd', 'shell:testNode', 'shell:testRhino', 'jasmine:coverage']);
+
+  //task for debugging in browser
+  grunt.registerTask('dev',          ['build', 'jasmine:testDev:build', 'connect:testServer','log:testClient', 'watch:lib']);
+
+  //task to run unit tests on client against prod version of code
+  grunt.registerTask('testClient',   ['build', 'jasmine:testProd:build', 'connect:testServer', 'log:testClient', 'watch:lib_test']);
+
+  //coverage report
+  grunt.registerTask('coverage',     ['jasmine:coverage', 'log:coverage']);
 
   //release tasks
-  grunt.registerTask('buildRelease',    ['test', 'copy:release', 'compress']);
+  grunt.registerTask('buildRelease', ['test', 'copy:release', 'compress']);
   grunt.registerTask('releasePatch', ['bump-only:patch', 'buildRelease', 'shell:gitAddArchive', 'bump-commit']);
   grunt.registerTask('releaseMinor', ['bump-only:minor', 'buildRelease', 'shell:gitAddArchive', 'bump-commit']);
 
   //default task - full test
-  grunt.registerTask('default', ['test']);
+  grunt.registerTask('default',      ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-jasmine": "~0.5.2",
     "grunt-template-jasmine-istanbul": "~0.2.5",
+    "grunt-contrib-connect": "~0.5.0",
+    "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-uglify": "~0.3.0",
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-clean": "~0.5.0",


### PR DESCRIPTION
There is no clearly defined and documented way to debug unminified dust-helpers.js code. Adding this ability with `grunt testClient` task. It is the same approach as in main dust repo (although testClient task uses unminified source file there).

Additionally coverage report generated by jasmine task was based on minified dust-helper.js file. It was hard to tell which lines were covered, since all of it was just one line. Moved out coverage task as a separate task and made it generate report based on unminified source code.

Added `grunt watch` task to be in line with main dust project and just because it's handy :)

Also update README.md to provide instructions on how all of these tasks should be used.

With these updates travis build will run unit tests against minified dust helpers code in Phantom, Node and Rhino. It will also run coverage report against unminified source code. If coverage thresholds are not met, build will fail.
