### PR TITLE
add optional 'start' param to '{@idx}'

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -157,10 +157,16 @@ var helpers = {
     }
   },
 
-  "idx": function(chunk, context, bodies) {
+  "idx": function(chunk, context, bodies, params) {
+    var start = 0;
+
+    if (params) {
+        start = +dust.helpers.tap(params.start, chunk, context) || start;
+    } 
+
     var body = bodies.block;
      if(body) {
-       return bodies.block(chunk, context.push(context.stack.index));
+       return bodies.block(chunk, context.push(context.stack.index + start));
      }
      else {
        return chunk;

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1263,6 +1263,20 @@ var helpersTests = [
         context:  { n: ["Mick", "Tom", "Bob"] },
         expected: "0>>Hello Mick! You have 30 new messages.1>>Hello Tom! You have 30 new messages.2>>Hello Bob! You have 30 new messages.",
         message: "should test idx helper within partial included in a array"
+      },
+      {
+        name:     "idx helper within partial included in a array (start param (=0) given)",
+        source:   '{#n}{@idx start="0"}{.}>>{/idx}{>hello_there name=. count="30"/}{/n}',
+        context:  { n: ["Mick", "Tom", "Bob"] },
+        expected: "0>>Hello Mick! You have 30 new messages.1>>Hello Tom! You have 30 new messages.2>>Hello Bob! You have 30 new messages.",
+        message: "should test idx helper within partial included in a array"
+      },
+      {
+        name:     "idx helper within partial included in a array (start param (=5) given)",
+        source:   '{#n}{@idx start="5"}{.}>>{/idx}{>hello_there name=. count="30"/}{/n}',
+        context:  { n: ["Mick", "Tom", "Bob"] },
+        expected: "5>>Hello Mick! You have 30 new messages.6>>Hello Tom! You have 30 new messages.7>>Hello Bob! You have 30 new messages.",
+        message: "should test idx helper within partial included in a array"
       }
     ]
   },


### PR DESCRIPTION
currently, if you want to use `{$idx}` as a 1-based index, you need to do something like this:
```
{@math key="{$idx}" method="add" operand="1" /}
````

with this pull request, the idx helper gets a new optional param `start` which will allow doing something like:
```
{@idx start="1"}{.}{/idx}
```
