### PR TITLE
Fix dustjs version to support new releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "helpers"
   ],
   "dependencies": {
-    "dustjs-linkedin": "~2.3.0"
+    "dustjs-linkedin": "2.x"
   },
   "devDependencies": {
     "jasmine-node": "~1.13.0",


### PR DESCRIPTION
Since [dustjs-linkedin](https://www.npmjs.org/package/dustjs-linkedin) package was updated to version 2.4.0 helpers stop work because dust-helpers package depends on 2.3.x versions and npm installs one more package  dusts-linkedin@2.3.5 and helpers are registered in wrong dust module because of [require algorithm](http://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders).

According [semver](https://github.com/isaacs/node-semver) rules all changes until 3.x.x version should be compatible with all old code including dust-helpers.

I think in this case we can specify dustjs-linkedin 2.x version as a dependency of dust-helpers and be sure that helpers will be supported until 3 version.
