### PR TITLE
switched console.log for dust.log

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -1,5 +1,8 @@
 (function(dust){
 
+//using the built in logging method of dust when accessible
+var _log = dust.log ? function(mssg) { dust.log(mssg, "INFO"); } : function() {};
+
 function isSelect(context) {
   var value = context.current();
   return typeof value === "object" && value.isSelect === true;
@@ -42,7 +45,7 @@ function filter(chunk, context, bodies, params, filterOp) {
     }
   }
   else {
-    dust.log("No key specified for filter in:" + filterOpType + " helper ", "INFO");
+    _log("No key specified for filter in:" + filterOpType + " helper ");
     return chunk;
   }
   expectedValue = dust.helpers.tap(params.value, chunk, context);
@@ -56,7 +59,7 @@ function filter(chunk, context, bodies, params, filterOp) {
      return chunk.render(body, context);
     }
     else {
-      dust.log("No key specified for filter in:" + filterOpType + " helper ", "INFO");
+      _log("No key specified for filter in:" + filterOpType + " helper ");
       return chunk;
     }
    }
@@ -176,7 +179,7 @@ var helpers = {
       dump = JSON.stringify(context.stack.head, jsonFilter, 2);
     }
     if (to === 'console') {
-      dust.log(dump, "INFO");
+      _log(dump);
       return chunk;
     }
     else {
@@ -211,7 +214,7 @@ var helpers = {
         return chunk.render( bodies.block, context );
        }
        else {
-         dust.log("Missing body block in the if helper!", "INFO");           
+         _log("Missing body block in the if helper!");
          return chunk;
        }
       }
@@ -221,7 +224,7 @@ var helpers = {
     }
     // no condition
     else {
-      dust.log("No condition given in the if helper!", "INFO");        
+      _log("No condition given in the if helper!");
     }
     return chunk;
   },
@@ -243,7 +246,7 @@ var helpers = {
           round = params.round,
           mathOut = null,
           operError = function(){
-              dust.log("operand is required for this math method", "INFO");
+              _log("operand is required for this math method");
               return null;
           };
       key  = dust.helpers.tap(key, chunk, context);
@@ -252,7 +255,7 @@ var helpers = {
       switch(method) {
         case "mod":
           if(operand === 0 || operand === -0) {
-            dust.log("operand for divide operation is 0/-0: expect Nan!", "INFO");
+            _log("operand for divide operation is 0/-0: expect Nan!");
           }
           mathOut = parseFloat(key) %  parseFloat(operand);
           break;
@@ -267,7 +270,7 @@ var helpers = {
           break;
         case "divide":
          if(operand === 0 || operand === -0) {
-           dust.log("operand for divide operation is 0/-0: expect Nan/Infinity!", "INFO");  
+           _log("operand for divide operation is 0/-0: expect Nan/Infinity!");
          }
           mathOut = parseFloat(key) / parseFloat(operand);
           break;
@@ -284,7 +287,7 @@ var helpers = {
           mathOut = Math.abs(parseFloat(key));
           break;
         default:
-          dust.log("method passed is not supported", "INFO");              
+          _log("method passed is not supported");
      }
 
       if (mathOut !== null){
@@ -305,7 +308,7 @@ var helpers = {
     }
     // no key parameter and no method
     else {
-      dust.log("Key is a required parameter for math helper along with method/operand!", "INFO");        
+      _log("Key is a required parameter for math helper along with method/operand!");
     }
     return chunk;
   },
@@ -328,13 +331,13 @@ var helpers = {
        return chunk.render(bodies.block, context.push({ isSelect: true, isResolved: false, selectKey: key }));
       }
       else {
-       dust.log("Missing body block in the select helper ", "INFO");
+       _log("Missing body block in the select helper ");
        return chunk;
       }
     }
     // no key
     else {
-      dust.log("No key given in the select helper!", "INFO");        
+      _log("No key given in the select helper!");
     }
     return chunk;
   },


### PR DESCRIPTION
in a production environment (client or server) it is not appropriate to
log errors to the console.
helpers now log errors via the dust.log method using the "INFO" key so
that it is possible to activate logging of error messages via the log
level that has been assigned to the dust core.

fixes #86
