### PR TITLE
use peerDependencies instead of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "dustjs-linkedin": "~2.4.0"
   },
   "devDependencies": {
+    "dustjs-linkedin": "~2.4.0",
     "jasmine-node": "~1.13.0",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",


### PR DESCRIPTION
Because the user might need a different version of dustjs linkedin or might have other
modules using his version of dust, this allows for more use cases to work properly
