### PR TITLE
Change peerDep to ^ form. Update contributors

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,38 +8,18 @@
   "homepage": "https://github.com/linkedin/dustjs-helpers",
   "description": "Helpers for dustjs-linkedin package",
   "contributors": [
-    {
-      "name": "Jairo de Morais",
-      "email": "jdemorais@linkedin.com"
-    },
-    {
-      "name": "Yevgeniy Brikman",
-      "email": "jbrikman@linkedin.com"
-    },
-    {
-      "name": "Veena Basavaraj",
-      "email": "vbasavaraj@linkedin.com"
-    },
-    {
-      "name": "Johnathan Leppert",
-      "email": "jleppert@linkedin.com"
-    },
-    {
-      "name": "Jimmy Chan",
-      "email": "jchan@linkedin.com"
-    },
-    {
-      "name": "Richard Ragan",
-      "email": "rragan@ebay.com"
-    },
-    {
-      "name": "Sarah Clatterbuck",
-      "email": "sclatter@linkedin.com"
-    },
-    {
-      "name": "Kate Odnous",
-      "email": "kodnous@linkedin.com"
-    }
+    "Veena Basavaraj <veena.braj@gmail.com>",
+    "Yevgeniy Brikman",
+    "Tom Carchrae",
+    "Sarah Clatterbuck <sclatter@linkedin.com>",
+    "Jimmy Chan <jchan@linkedin.com>",
+    "Steven Foote <sfoote@linkedin.com>",
+    "Prayrit Prash Jain <prjain@linkedin.com>",
+    "Seth Kinast <skinast@linkedin.com>",
+    "Johnathan Leppert <jleppert@linkedin.com>",
+    "Jairo de Morais <jairodemorais@gmail.com>",
+    "Kate Odnous <kodnous@linkedin.com>",
+    "Richard Ragan <rragan@ebay.com>"
   ],
   "scripts": {
     "test": "grunt test"
@@ -55,10 +35,10 @@
     "helpers"
   ],
   "peerDependencies": {
-    "dustjs-linkedin": "~2.4.0"
+    "dustjs-linkedin": "^2.4.0"
   },
   "devDependencies": {
-    "dustjs-linkedin": "~2.4.0",
+    "dustjs-linkedin": "^2.4.0",
     "jasmine-node": "~1.13.0",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",


### PR DESCRIPTION
Update contributors as done for linkedin-dustjs repo.  Change the recently added peerDependency to use the ^ semver form. The ~ form causes other peerDependency issues with other modules using ^2.4.0 for dustjs-linkedin peer dependencies. 