### PR TITLE
Use old-npm equivalent of ^2.4.0 for peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "helpers"
   ],
   "peerDependencies": {
-    "dustjs-linkedin": "~2.4.0"
+    "dustjs-linkedin": ">= 2.4.0 < 3"
   },
   "devDependencies": {
     "dustjs-linkedin": "~2.4.0",


### PR DESCRIPTION
Every time a new dustjs-linkedin is released, projects depending on `dustjs-linkedin@^2` and `dustjs-helpers@^1` will fail with unresolved peerDependencies, because the version range on dustjs-helpers is too strict, since `~2.4.0` is `>= 2.4.0 < 2.5.0`. Since ~ isn't really useful to follow semver, we want the equivalent of the `semver@2` `^` operator:

```
npm ERR! peerinvalid The package dustjs-linkedin does not satisfy its siblings' peerDependencies requirements!
npm ERR! peerinvalid Peer dustjs-helpers@1.3.0 wants dustjs-linkedin@~2.4.0
npm ERR! peerinvalid Peer makara@0.3.5 wants dustjs-linkedin@^2.0.0
npm ERR! peerinvalid Peer dusthelpers-supplement@0.0.10 wants dustjs-linkedin@^2.0.0
```
