### PR TITLE
Deprecate {@if} and {@idx}

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -1,7 +1,18 @@
 (function(dust){
 
-//using the built in logging method of dust when accessible
-var _log = dust.log ? function(mssg) { dust.log(mssg, "INFO"); } : function() {};
+// Use dust's built-in logging when available
+var _log = dust.log ? function(msg, level) {
+  level = level || "INFO";
+  dust.log(msg, level);
+} : function() {};
+
+var _deprecatedCache = {};
+function _deprecated(target) {
+  if(_deprecatedCache[target]) { return; }
+  _log("Deprecation warning: " + target + " is deprecated and will be removed in a future version of dustjs-helpers", "WARN");
+  _log("For help and a deprecation timeline, see https://github.com/linkedin/dustjs-helpers/wiki/Deprecated-Features#" + target.replace(/\W+/g, ""), "WARN");
+  _deprecatedCache[target] = true;
+}
 
 function isSelect(context) {
   var value = context.current();
@@ -139,22 +150,23 @@ var helpers = {
     if (context.stack.index === context.stack.of - 1) {
       return chunk;
     }
-    if(body) {
-     return bodies.block(chunk, context);
-    }
-    else {
-     return chunk;
+    if (body) {
+      return body(chunk, context);
+    } else {
+      return chunk;
     }
   },
 
   "idx": function(chunk, context, bodies) {
     var body = bodies.block;
-     if(body) {
-       return bodies.block(chunk, context.push(context.stack.index));
-     }
-     else {
-       return chunk;
-     }
+    // Will be removed in 1.6
+    _deprecated("{@idx}");
+    if(body) {
+      return body(chunk, context.push(context.stack.index));
+    }
+    else {
+      return chunk;
+    }
   },
 
   /**
@@ -204,12 +216,16 @@ var helpers = {
     cond argument should evaluate to a valid javascript expression
    **/
 
-  "if": function( chunk, context, bodies, params ){
+  "if": function( chunk, context, bodies, params ) {
     var body = bodies.block,
-        skip = bodies['else'];
-    if( params && params.cond){
-      var cond = params.cond;
-      cond = dust.helpers.tap(cond, chunk, context);
+        skip = bodies['else'],
+        cond;
+
+    if(params && params.cond) {
+      // Will be removed in 1.6
+      _deprecated("{@if}");
+
+      cond = dust.helpers.tap(params.cond, chunk, context);
       // eval expressions with given dust references
       if(eval(cond)){
        if(body) {


### PR DESCRIPTION
Generates a WARN when these helpers are used. This would go into helpers 1.4.x, and these two helpers would be removed in 1.5.x.
