### PR TITLE
Coerce falsy values when a type is specified by a comparison helper.

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -70,14 +70,13 @@ function filter(chunk, context, bodies, params, filterOp) {
 }
 
 function coerce (value, type, context) {
-  if (value) {
-    switch (type || typeof(value)) {
+  if (typeof value !== "undefined") {
+    switch (type || typeof value) {
       case 'number': return +value;
       case 'string': return String(value);
-      case 'boolean': {
+      case 'boolean':
         value = (value === 'false' ? false : value);
         return Boolean(value);
-      }
       case 'date': return new Date(value);
       case 'context': return context.get(value);
     }

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -538,6 +538,13 @@
          message: "eq helper non equal boolean case"
       },
       {
+         name:     "eq helper coerce falsy case",
+         source:   "{@eq key=x value=\"0\" type=\"string\"}equal{/eq}",
+         context:  {x:0},
+         expected: "equal",
+         message: "eq helper should coerce falsy booleans"
+      },
+      {
         name:     "eq helper without a body",
         source:   "{@eq key=\"abc\" value=\"java\"/}",
         context:  {},


### PR DESCRIPTION
Closes #85.
