### PR TITLE
Add {@none} helper as the converse to {@any}

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -500,11 +500,40 @@ var helpers = {
     } else {
       selectState = getSelectState(context);
       if(selectState.isDeferredComplete) {
-        _log("{@any} nested inside {@any} block. It needs its own {@select} block", "WARN");
+        _log("{@any} nested inside {@any} or {@none} block. It needs its own {@select} block", "WARN");
       } else {
         chunk = chunk.map(function(chunk) {
           selectState.deferreds.push(function() {
             if(selectState.isResolved && !selectState.isDefaulted) {
+              chunk = chunk.render(bodies.block, context);
+            }
+            chunk.end();
+          });
+        });
+      }
+    }
+    return chunk;
+  },
+
+  /**
+   * {@none}
+   * Outputs if no truth tests inside a {@select} pass.
+   * Must be contained inside a {@select} block.
+   * The position of the helper does not matter.
+   */
+  "none": function(chunk, context, bodies, params) {
+    var selectState;
+
+    if(!isSelect(context)) {
+      _log("{@none} used outside of a {@select} block", "WARN");
+    } else {
+      selectState = getSelectState(context);
+      if(selectState.isDeferredComplete) {
+        _log("{@none} nested inside {@any} or {@none} block. It needs its own {@select} block", "WARN");
+      } else {
+        chunk = chunk.map(function(chunk) {
+          selectState.deferreds.push(function() {
+            if(!selectState.isResolved) {
               chunk = chunk.render(bodies.block, context);
             }
             chunk.end();
@@ -522,6 +551,8 @@ var helpers = {
    */
   "default": function(chunk, context, bodies, params) {
     params.filterOpType = "default";
+    // Deprecated for removal in 1.7
+    _deprecated("{@default}");
     if(!isSelect(context)) {
       _log("{@default} used outside of a {@select} block", "WARN");
       return chunk;

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1124,6 +1124,54 @@
     ]
   },
   {
+    name: "none",
+    tests: [
+      {
+        name: "none without select",
+        source: '{@none}Hello{/none}',
+        context: { none: 'abc'},
+        expected: "",
+        message: "none helper outside of select does not render"
+      },
+      {
+        name: "none in select with no cases",
+        source: '{@select key=foo}{@none}Hello{/none}{/select}',
+        context: { foo: "bar"},
+        expected: "Hello",
+        message: "none helper with no cases in the select renders"
+      },
+      {
+        name: "none in select with no true cases",
+        source: '{@select key=foo}{@eq value=1/}{@none}Hello{/none}{/select}',
+        context: { foo: "bar"},
+        expected: "Hello",
+        message: "none helper with no true cases in the select renders"
+      },
+      {
+        name: "none in select with one true case",
+        source: '{@select key=foo}{@eq value="bar"/}{@none}Hello{/none}{/select}',
+        context: { foo: "bar"},
+        expected: "",
+        message: "none helper with a true case in the select does not render"
+      },
+      {
+        name: "multiple none helpers",
+        source: '{@select key=foo}{@none}Hello{/none}{@eq value="cow"/}{@none} World{/none}{/select}',
+        context: { foo: "bar"},
+        expected: "Hello World",
+        message: "multiple none helpers in the same select all render"
+      },
+      {
+        name: "none nested in an none properly with its own select",
+        source: '{@select key=foo}{@eq value="bar"/}{@none}Hello{@select key=moo}{@eq value="cow"/}{@none} World{/none}{/select}{/none}{/select}',
+        context: { foo: true, moo: true},
+        expected: "Hello World",
+        message: "a none helper must have its own select to render"
+      }
+
+    ]
+  },
+  {
     name: "size",
     tests: [
       {


### PR DESCRIPTION
This also sets up {@default} for deprecation.

{@none} is simply the improved version of {@default}-- you can have more than one of them, and they can appear anywhere in the {@select} block but are evaluated asynchronously.