### PR TITLE
Remove @if and @idx

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -180,18 +180,6 @@ var helpers = {
     }
   },
 
-  "idx": function(chunk, context, bodies) {
-    var body = bodies.block;
-    // Will be removed in 1.6
-    _deprecated("{@idx}");
-    if(body) {
-      return body(chunk, context.push(context.stack.index));
-    }
-    else {
-      return chunk;
-    }
-  },
-
   /**
    * contextDump helper
    * @param key specifies how much to dump.
@@ -238,37 +226,6 @@ var helpers = {
                 a dust reference is also enclosed in double quotes, e.g. cond="'{val}'' > 3"
     cond argument should evaluate to a valid javascript expression
    **/
-
-  "if": function( chunk, context, bodies, params ) {
-    var body = bodies.block,
-        skip = bodies['else'],
-        cond;
-
-    if(params && params.cond) {
-      // Will be removed in 1.6
-      _deprecated("{@if}");
-
-      cond = dust.helpers.tap(params.cond, chunk, context);
-      // eval expressions with given dust references
-      if(eval(cond)){
-       if(body) {
-        return chunk.render( bodies.block, context );
-       }
-       else {
-         _log("Missing body block in the if helper!");
-         return chunk;
-       }
-      }
-      if(skip){
-       return chunk.render( bodies['else'], context );
-      }
-    }
-    // no condition
-    else {
-      _log("No condition given in the if helper!");
-    }
-    return chunk;
-  },
 
   /**
    * math helper

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -14,60 +14,6 @@
     ]
   },
   {
-    name: "if",
-    tests: [
-      {
-        name:     "if helper with no body",
-        source:   '{@if cond="{x}<{y}"/}',
-        context:  { x: 2, y: 3 },
-        expected: "",
-        message: "should test if helper with no body and fail gracefully"
-      },
-      {
-        name:     "if helper with no condition",
-        source:   '{@if}Hello{/if}',
-        context:  { x: 2, y: 3 },
-        expected: "",
-        message: "should test if helper with no condition fails gracefully"
-      },
-      {
-        name:     "if helper without else",
-        source:   '{@if cond="{x}<{y}"}<div> X < Y </div>{/if}',
-        context:  { x: 2, y: 3 },
-        expected: "<div> X < Y </div>",
-        message: "should test if helper without else"
-      },
-      {
-        name:     "if helper with else block",
-        source:   '{@if cond=" \'{x}\'.length && \'{y}\'.length "}<div> X and Y exists </div>{:else}<div> X and Y does not exists </div>{/if}',
-        context:  {},
-        expected: "<div> X and Y does not exists </div>",
-        message: "should test if helper with else block"
-      },
-      {
-        name:     "if helper with else using the or condition",
-        source:   '{@if cond=" \'{x}\'.length || \'{y}\'.length "}<div> X or Y exists </div>{:else}<div> X or Y does not exists </div>{/if}',
-        context:  { x: 1},
-        expected: "<div> X or Y exists </div>",
-        message: "should test if helper with else using the or condition"
-      },
-      {
-        name:     "if helper with else using the and conditon",
-        source:   '{@if cond="( \'{x}\'.length ) && ({x}<3)"}<div> X exists and is 1 </div>{:else}<div> x is not there </div>{/if}',
-        context:  { x : 1},
-        expected: "<div> X exists and is 1 </div>",
-        message: "should test if helper with else usingt he and conditon"
-      },
-      {
-        name:     "if helper using $idx",
-        source:   '{#list}{@if cond="( {$idx} == 1 )"}<div>{y}</div>{/if}{/list}',
-        context:  { x : 1, list: [ { y: 'foo' }, { y: 'bar'} ]},
-        expected: "<div>bar</div>",
-        message: "should test the if helper using $idx"
-      }
-    ]
-  },
-  {
     name: "math",
     tests: [
       {
@@ -1427,25 +1373,6 @@
           context:  { "A": "<html>", "B": "</html>"},
           expected: "{\n  \"A\": \"\\u003chtml>\",\n  \"B\": \"\\u003c/html>\"\n}",
           message: "contextDump simple test"
-      }
-    ]
-  },
-  {
-    name: "idx",
-    tests: [
-      {
-        name:     "idx helper with no body",
-        source:   '{#n}{@idx/}{.} {/n}',
-        context:  { n: ["Mick", "Tom", "Bob"] },
-        expected: "Mick Tom Bob ",
-        message: "idx helper with no body should not render"
-      },
-      {
-        name:     "idx helper within partial included in a array",
-        source:   '{#n}{@idx}{.}>>{/idx}{>hello_there name=. count="30"/}{/n}',
-        context:  { n: ["Mick", "Tom", "Bob"] },
-        expected: "0>>Hello Mick! You have 30 new messages.1>>Hello Tom! You have 30 new messages.2>>Hello Bob! You have 30 new messages.",
-        message: "should test idx helper within partial included in a array"
       }
     ]
   },


### PR DESCRIPTION
closes #95. Following up with #102 where the `idx` and the `if` helpers were deprecated, this pull request finally removes these helpers.

With all the other helpers coming in, `if` is just unnecessary.  This is breaks back compat so a 1.6.X branch is desirable.