### PR TITLE
Improvements to checking for the existence of a {@select} state.

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -28,7 +28,7 @@ function isSelect(context) {
 }
 
 function getSelectState(context) {
-  return context.get('__select__');
+  return isSelect(context) && context.get('__select__');
 }
 
 function addSelectState(context, key) {
@@ -75,7 +75,7 @@ function filter(chunk, context, bodies, params, filterOp) {
   var body = bodies.block,
       actualKey,
       expectedValue,
-      selectState,
+      selectState = getSelectState(context),
       filterOpType = params.filterOpType || '';
 
   // Currently we first check for a key on the helper itself, then fall back to
@@ -84,8 +84,7 @@ function filter(chunk, context, bodies, params, filterOp) {
   // it, just switch the order of the test below to check the {@select} first.)
   if (params.hasOwnProperty("key")) {
     actualKey = dust.helpers.tap(params.key, chunk, context);
-  } else if (isSelect(context)) {
-    selectState = getSelectState(context);
+  } else if (selectState) {
     actualKey = selectState.key;
     // Once one truth test in a select passes, short-circuit the rest of the tests
     if (selectState.isResolved) {
@@ -98,7 +97,7 @@ function filter(chunk, context, bodies, params, filterOp) {
   expectedValue = dust.helpers.tap(params.value, chunk, context);
   // coerce both the actualKey and expectedValue to the same type for equality and non-equality compares
   if (filterOp(coerce(expectedValue, params.type, context), coerce(actualKey, params.type, context))) {
-    if (isSelect(context)) {
+    if (selectState) {
       if(filterOpType === 'default') {
         selectState.isDefaulted = true;
       }
@@ -476,12 +475,11 @@ var helpers = {
    * The passing truth test can be before or after the {@any} block.
    */
   "any": function(chunk, context, bodies, params) {
-    var selectState;
+    var selectState = getSelectState(context);
 
-    if(!isSelect(context)) {
+    if(!selectState) {
       _log("{@any} used outside of a {@select} block", "WARN");
     } else {
-      selectState = getSelectState(context);
       if(selectState.isDeferredComplete) {
         _log("{@any} nested inside {@any} or {@none} block. It needs its own {@select} block", "WARN");
       } else {
@@ -505,12 +503,11 @@ var helpers = {
    * The position of the helper does not matter.
    */
   "none": function(chunk, context, bodies, params) {
-    var selectState;
+    var selectState = getSelectState(context);
 
-    if(!isSelect(context)) {
+    if(!selectState) {
       _log("{@none} used outside of a {@select} block", "WARN");
     } else {
-      selectState = getSelectState(context);
       if(selectState.isDeferredComplete) {
         _log("{@none} nested inside {@any} or {@none} block. It needs its own {@select} block", "WARN");
       } else {

--- a/test/jasmine-test/spec/helpersTests.js
+++ b/test/jasmine-test/spec/helpersTests.js
@@ -1117,6 +1117,13 @@
         context: { foo: "bar", moo: "cow"},
         expected: "Hello World",
         message: "an any helper must have its own select to render"
+      },
+      {
+        name: "any with a multikey select",
+        source: '{@select key=one}{@eq value="true"/}{@eq key=two value="true"/}{@any}Hello{/any}{/select}',
+        context: { one: "false", two: "true" },
+        expected: "Hello",
+        message: "any helpers inside multikey selects render"
       }
     ]
   },


### PR DESCRIPTION
The most immediate effect of this change is the ability to use {@any} and {@none} with multikey selects (still an undocumented feature)

Closes #124 