### PR TITLE
protect when context.stack.tail.head is undefined

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -25,7 +25,7 @@ function _deprecated(target) {
 
 function isSelect(context) {
   return context.stack.tail &&
-  	 context.stack.tail.head &&
+         context.stack.tail.head &&
          typeof context.stack.tail.head.__select__ !== "undefined";
 }
 

--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -25,6 +25,7 @@ function _deprecated(target) {
 
 function isSelect(context) {
   return context.stack.tail &&
+  	 context.stack.tail.head &&
          typeof context.stack.tail.head.__select__ !== "undefined";
 }
 


### PR DESCRIPTION
PayPal hit a problem with just @eq in a template blowing up because context.stack.tail.head.__select__ was failing with trying to read __select__ from undefined. Adding an extra check to protect that makes the PayPal app run OK now. 

An abstracted version of the template with the problem is:
```
{>"layouts/master" /}
<head>
elided material
</head>
{<body}
    {@eq key=access_type value="MODIFY"}
    <ul class="nav" role="tablist">
      <li class="dropdown">
  elided material
      </li>
    </ul>

    <div class="tab-content">
elided material
     </div>
    </div>
    {:else}
    <h3 style="text-align:center"> elided material</h3>
    {/eq}
{/body}
```