### PR TITLE
Support {:else} blocks in @first, @last

### DIFF
--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -191,14 +191,16 @@ var helpers = {
     if (context.stack.index === 0) {
       return bodies.block(chunk, context);
     }
-    return chunk;
+
+    return bodies.else ? bodies.else(chunk, context) : chunk;
   },
 
   "last": function(chunk, context, bodies) {
     if (context.stack.index === context.stack.of - 1) {
       return bodies.block(chunk, context);
     }
-    return chunk;
+
+    return bodies.else ? bodies.else(chunk, context) : chunk;
   },
 
   /**


### PR DESCRIPTION
Simple PR to add support for `{:else}` in `@first` and `@last` helpers, per https://github.com/linkedin/dustjs/issues/720.

- Passes all tests: `575 tests, 837 assertions, 0 failures, 0 skipped`
- Docs still need to be updated (is there a place to submit PRs for documentation?)