### PR TITLE
fix: use the dust context which is passed in arg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 *.DS_Store
 .*.sw[a-z]
 *.un~

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "8"
 matrix:
   include:
-      node_js: "0.10"
+    - node_js: "0.10"
       env: TEST="all"
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: node_js
 node_js:
   - "0.12"
-  - "iojs"
+  - "4"
+  - "6"
+  - "8"
 matrix:
   include:
-    - node_js: "0.10"
+      node_js: "0.10"
       env: TEST="all"
 notifications:
   email:

--- a/lib/dust-helpers.js
+++ b/lib/dust-helpers.js
@@ -3,6 +3,7 @@
     define(['dust.core'], factory);
   } else if (typeof exports === 'object') {
     module.exports = factory(require('dustjs-linkedin'));
+    module.exports.registerWith = factory;
   } else {
     factory(root.dust);
   }


### PR DESCRIPTION
In node 8, when using factory(require('dustjs-linkedin'), it seems it creates a new dust context/object and assign dust.helpers to it, because of which actual dust.helpers was {}. So we were loosing all the dust-helpers. 

Ideally it should refer to same cached dustjs-linkedin object, but it's not happening. Also, i didn't understand why we are requiring it separately when it's is already expecting a function and passing  `dust` in arg i.e module.exports = function(dust, options) {}  // for dust helpers.

Solution is: use the dust object coming as arg instead of requiring it again. 